### PR TITLE
Add ReversedMatchingOrder option to use latest matcher

### DIFF
--- a/option.go
+++ b/option.go
@@ -20,9 +20,18 @@ type config struct {
 	openAPI3Validator                   *validator.Validator
 	skipValidateRequest                 bool
 	skipValidateResponse                bool
+	reversedMatchingOrder               bool
 }
 
 type Option func(*config) error
+
+// ReversedMatchingOrder reverses matching order.
+func ReversedMatchingOrder() Option {
+	return func(c *config) error {
+		c.reversedMatchingOrder = true
+		return nil
+	}
+}
 
 // OpenApi3 sets OpenAPI Document using file path.
 func OpenApi3(l string) Option {


### PR DESCRIPTION
Hi!

This PR  added option `ReversedMatchingOrder` to use newer matcher.
For example, a SUT make three requests with following order.

1. GET /api/users/1
2. POST /api/users/1
3. GET /api/users/1

If the 2nd request have updated the user(id=1), expected response of the 3rd request contains updated user info.
But current implementation always matches the 1st `GET /api/users/1` and responds old user info.

For the above usecase, I need this new option.
Please take it in consideration.

Thank you.