### PR TITLE
feat: add `Addr` option for custom server address

### DIFF
--- a/httpstub_test.go
+++ b/httpstub_test.go
@@ -874,6 +874,93 @@ func TestURL(t *testing.T) {
 		}
 	}
 }
+func TestAddr(t *testing.T) {
+	rt := NewRouter(t, Addr("127.0.0.1:12345"))
+	rt.Method(http.MethodGet).Path("/api/v1/users/1").Header("Content-Type", "application/json").ResponseString(http.StatusOK, `{"name":"alice"}`)
+	ts := rt.Server()
+	t.Cleanup(func() {
+		ts.Close()
+	})
+	tc := ts.Client()
+
+	res, err := tc.Get("https://example.com/api/v1/users/1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		res.Body.Close()
+	})
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	{
+		got := res.StatusCode
+		want := http.StatusOK
+		if got != want {
+			t.Errorf("got %v\nwant %v", got, want)
+		}
+	}
+	{
+		got := string(body)
+		want := `{"name":"alice"}`
+		if got != want {
+			t.Errorf("got %v\nwant %v", got, want)
+		}
+	}
+	{
+		got := rt.URL
+		want := "http://127.0.0.1:12345"
+		if got != want {
+			t.Errorf("got %v\nwant %v", got, want)
+		}
+	}
+}
+
+func TestAddrTLS(t *testing.T) {
+	rt := NewRouter(t, Addr("127.0.0.1:12345"))
+	rt.Method(http.MethodGet).Path("/api/v1/users/1").Header("Content-Type", "application/json").ResponseString(http.StatusOK, `{"name":"alice"}`)
+	ts := rt.TLSServer()
+	t.Cleanup(func() {
+		ts.Close()
+	})
+	tc := ts.Client()
+
+	res, err := tc.Get("https://example.com/api/v1/users/1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		res.Body.Close()
+	})
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	{
+		got := res.StatusCode
+		want := http.StatusOK
+		if got != want {
+			t.Errorf("got %v\nwant %v", got, want)
+		}
+	}
+	{
+		got := string(body)
+		want := `{"name":"alice"}`
+		if got != want {
+			t.Errorf("got %v\nwant %v", got, want)
+		}
+	}
+	{
+		got := rt.URL
+		want := "https://127.0.0.1:12345"
+		if got != want {
+			t.Errorf("got %v\nwant %v", got, want)
+		}
+	}
+}
 
 func BenchmarkNewServer(b *testing.B) {
 	for i := 0; i < b.N; i++ {

--- a/option.go
+++ b/option.go
@@ -23,6 +23,7 @@ type config struct {
 	skipValidateRequest                 bool
 	skipValidateResponse                bool
 	skipCircularReferenceCheck          bool
+	addr                                string
 }
 
 type Option func(*config) error
@@ -185,6 +186,14 @@ func ClientCertificates(cert, key []byte) Option {
 func ClientCACert(cacert []byte) Option {
 	return func(c *config) error {
 		c.clientCacert = cacert
+		return nil
+	}
+}
+
+// Addr set server address.
+func Addr(addr string) Option {
+	return func(c *config) error {
+		c.addr = addr
 		return nil
 	}
 }


### PR DESCRIPTION
This pull request adds support for specifying a custom address for the HTTP stub server. This enhancement allows users to control the host and port that the test server binds to, both for HTTP and HTTPS (TLS) modes. The changes include updates to the configuration, server startup logic, and new tests to verify this functionality.

**Support for custom server address:**

- Added an `addr` field to the `config` and `Router` structs, and implemented the `Addr` option function to allow users to set a custom server address when creating a new router. [[1]](diffhunk://#diff-086a37ef11c8fd9a2516991339db79c207741ac98dd89c8215d31a8bead2814fR26) [[2]](diffhunk://#diff-086a37ef11c8fd9a2516991339db79c207741ac98dd89c8215d31a8bead2814fR192-R199) [[3]](diffhunk://#diff-8f05c55c5e537f5720313d8ba498403a196f37a6fb351090c8fc3e845cfeae38R63) [[4]](diffhunk://#diff-8f05c55c5e537f5720313d8ba498403a196f37a6fb351090c8fc3e845cfeae38R151)
- Updated the `Server` and TLS server startup logic in `httpstub.go` to bind the test server to the specified address if provided, both for HTTP and HTTPS. This includes handling the listener setup and error cases. [[1]](diffhunk://#diff-8f05c55c5e537f5720313d8ba498403a196f37a6fb351090c8fc3e845cfeae38R194-R205) [[2]](diffhunk://#diff-8f05c55c5e537f5720313d8ba498403a196f37a6fb351090c8fc3e845cfeae38L261-R289) [[3]](diffhunk://#diff-8f05c55c5e537f5720313d8ba498403a196f37a6fb351090c8fc3e845cfeae38R14)

**Testing:**

- Added new tests `TestAddr` and `TestAddrTLS` in `httpstub_test.go` to verify that the server correctly binds to the specified address and responds as expected for both HTTP and HTTPS modes.