### PR TITLE
feat: add `BaseURL` option for baseURL configuration

### DIFF
--- a/httpstub_test.go
+++ b/httpstub_test.go
@@ -961,6 +961,79 @@ func TestAddrTLS(t *testing.T) {
 		}
 	}
 }
+func TestBaseURL(t *testing.T) {
+	rt := NewRouter(t, BaseURL("/api/v1"))
+	rt.Method(http.MethodGet).Path("/users/1").Header("Content-Type", "application/json").ResponseString(http.StatusOK, `{"name":"alice"}`)
+	ts := rt.Server()
+	t.Cleanup(func() {
+		ts.Close()
+	})
+	tc := ts.Client()
+
+	res, err := tc.Get("https://example.com/api/v1/users/1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		res.Body.Close()
+	})
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	{
+		got := res.StatusCode
+		want := http.StatusOK
+		if got != want {
+			t.Errorf("got %v\nwant %v", got, want)
+		}
+	}
+	{
+		got := string(body)
+		want := `{"name":"alice"}`
+		if got != want {
+			t.Errorf("got %v\nwant %v", got, want)
+		}
+	}
+}
+
+func TestBaseURLTLS(t *testing.T) {
+	rt := NewRouter(t, BaseURL("/api/v1"))
+	rt.Method(http.MethodGet).Path("/users/1").Header("Content-Type", "application/json").ResponseString(http.StatusOK, `{"name":"alice"}`)
+	ts := rt.TLSServer()
+	t.Cleanup(func() {
+		ts.Close()
+	})
+	tc := ts.Client()
+
+	res, err := tc.Get("https://example.com/api/v1/users/1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		res.Body.Close()
+	})
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	{
+		got := res.StatusCode
+		want := http.StatusOK
+		if got != want {
+			t.Errorf("got %v\nwant %v", got, want)
+		}
+	}
+	{
+		got := string(body)
+		want := `{"name":"alice"}`
+		if got != want {
+			t.Errorf("got %v\nwant %v", got, want)
+		}
+	}
+}
 
 func BenchmarkNewServer(b *testing.B) {
 	for i := 0; i < b.N; i++ {

--- a/option.go
+++ b/option.go
@@ -24,6 +24,7 @@ type config struct {
 	skipValidateResponse                bool
 	skipCircularReferenceCheck          bool
 	addr                                string
+	baseURL                             string
 }
 
 type Option func(*config) error
@@ -194,6 +195,14 @@ func ClientCACert(cacert []byte) Option {
 func Addr(addr string) Option {
 	return func(c *config) error {
 		c.addr = addr
+		return nil
+	}
+}
+
+// BaseURL set base URL path prefix.
+func BaseURL(baseURL string) Option {
+	return func(c *config) error {
+		c.baseURL = baseURL
 		return nil
 	}
 }


### PR DESCRIPTION
This pull request adds support for a configurable `baseURL` path prefix to the HTTP stub router, allowing all route matching and server transport logic to automatically prepend the specified base URL to paths. This makes it easier to test APIs that are served under a common path prefix. It also includes new tests to verify the correct behavior for both HTTP and HTTPS servers.

### Base URL support

* Added a `baseURL` field to the `Router` and its configuration, with a new `BaseURL` option for initialization. This allows users to specify a common path prefix for all routes. [[1]](diffhunk://#diff-8f05c55c5e537f5720313d8ba498403a196f37a6fb351090c8fc3e845cfeae38R64) [[2]](diffhunk://#diff-086a37ef11c8fd9a2516991339db79c207741ac98dd89c8215d31a8bead2814fR27) [[3]](diffhunk://#diff-086a37ef11c8fd9a2516991339db79c207741ac98dd89c8215d31a8bead2814fR201-R208)
* Updated route matching logic in `Router.Path` and `matcher.Path` to prepend `baseURL` to all route paths if set, ensuring consistent matching. [[1]](diffhunk://#diff-8f05c55c5e537f5720313d8ba498403a196f37a6fb351090c8fc3e845cfeae38R364-R372) [[2]](diffhunk://#diff-8f05c55c5e537f5720313d8ba498403a196f37a6fb351090c8fc3e845cfeae38R382-R386)
* Modified the HTTP transport setup to pass and use the `baseURL`, ensuring requests are routed with the correct prefix. [[1]](diffhunk://#diff-8f05c55c5e537f5720313d8ba498403a196f37a6fb351090c8fc3e845cfeae38L296-R298) [[2]](diffhunk://#diff-8f05c55c5e537f5720313d8ba498403a196f37a6fb351090c8fc3e845cfeae38R709-R717)

### Testing

* Added `TestBaseURL` and `TestBaseURLTLS` tests to verify that the router correctly matches and responds to requests with the configured base URL prefix for both HTTP and HTTPS servers.

These changes collectively make it easier to test APIs that are served under a versioned or prefixed path.