### PR TITLE
fix: Rename `BaseURL` to `BasePath`

### DIFF
--- a/httpstub.go
+++ b/httpstub.go
@@ -61,7 +61,7 @@ type Router struct {
 	skipValidateResponse                bool
 	prependOnce                         bool
 	addr                                string
-	baseURL                             string
+	basePath                            string
 	mu                                  sync.RWMutex
 }
 
@@ -150,7 +150,7 @@ func NewRouter(t TB, opts ...Option) *Router {
 		skipValidateRequest:  c.skipValidateRequest,
 		skipValidateResponse: c.skipValidateResponse,
 		addr:                 c.addr,
-		baseURL:              c.baseURL,
+		basePath:             c.basePath,
 	}
 	if err := rt.setOpenApi3Vaildator(); err != nil {
 		t.Fatal(err)
@@ -295,7 +295,7 @@ func (rt *Router) Server() *httptest.Server {
 	if !ok {
 		panic("failed to type assert to *http.Transport")
 	}
-	client.Transport = newTransport(rt.server.URL, rt.baseURL, tp)
+	client.Transport = newTransport(rt.server.URL, rt.basePath, tp)
 	rt.URL = rt.server.URL
 	return rt.server
 }
@@ -361,9 +361,9 @@ func (m *matcher) Method(method string) *matcher {
 func (rt *Router) Path(path string) *matcher {
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
-	// Prepend baseURL to path if baseURL is set
-	if rt.baseURL != "" {
-		u, _ := url.JoinPath(rt.baseURL, path)
+	// Prepend basePath to path if basePath is set
+	if rt.basePath != "" {
+		u, _ := url.JoinPath(rt.basePath, path)
 		path = u
 	}
 	fn := pathMatchFunc(path)
@@ -379,9 +379,9 @@ func (rt *Router) Path(path string) *matcher {
 func (m *matcher) Path(path string) *matcher {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	// Prepend baseURL to path if baseURL is set
-	if m.router != nil && m.router.baseURL != "" {
-		u, _ := url.JoinPath(m.router.baseURL, path)
+	// Prepend basePath to path if basePath is set
+	if m.router != nil && m.router.basePath != "" {
+		u, _ := url.JoinPath(m.router.basePath, path)
 		path = u
 	}
 	fn := pathMatchFunc(path)
@@ -705,17 +705,17 @@ func queryMatchFunc(key, value string) matchFunc {
 }
 
 type transport struct {
-	URL     *url.URL
-	baseURL string
-	tp      *http.Transport
+	URL      *url.URL
+	basePath string
+	tp       *http.Transport
 }
 
-func newTransport(rawURL string, baseURL string, tp *http.Transport) http.RoundTripper {
+func newTransport(rawURL string, basePath string, tp *http.Transport) http.RoundTripper {
 	u, _ := url.Parse(rawURL)
 	return &transport{
-		URL:     u,
-		baseURL: baseURL,
-		tp:      tp,
+		URL:      u,
+		basePath: basePath,
+		tp:       tp,
 	}
 }
 

--- a/httpstub_test.go
+++ b/httpstub_test.go
@@ -961,8 +961,8 @@ func TestAddrTLS(t *testing.T) {
 		}
 	}
 }
-func TestBaseURL(t *testing.T) {
-	rt := NewRouter(t, BaseURL("/api/v1"))
+func TestBasePath(t *testing.T) {
+	rt := NewRouter(t, BasePath("/api/v1"))
 	rt.Method(http.MethodGet).Path("/users/1").Header("Content-Type", "application/json").ResponseString(http.StatusOK, `{"name":"alice"}`)
 	ts := rt.Server()
 	t.Cleanup(func() {
@@ -998,8 +998,8 @@ func TestBaseURL(t *testing.T) {
 	}
 }
 
-func TestBaseURLTLS(t *testing.T) {
-	rt := NewRouter(t, BaseURL("/api/v1"))
+func TestBasePathTLS(t *testing.T) {
+	rt := NewRouter(t, BasePath("/api/v1"))
 	rt.Method(http.MethodGet).Path("/users/1").Header("Content-Type", "application/json").ResponseString(http.StatusOK, `{"name":"alice"}`)
 	ts := rt.TLSServer()
 	t.Cleanup(func() {

--- a/option.go
+++ b/option.go
@@ -24,7 +24,7 @@ type config struct {
 	skipValidateResponse                bool
 	skipCircularReferenceCheck          bool
 	addr                                string
-	baseURL                             string
+	basePath                            string
 }
 
 type Option func(*config) error
@@ -199,10 +199,10 @@ func Addr(addr string) Option {
 	}
 }
 
-// BaseURL set base URL path prefix.
-func BaseURL(baseURL string) Option {
+// BasePath set base URL path prefix.
+func BasePath(basePath string) Option {
 	return func(c *config) error {
-		c.baseURL = baseURL
+		c.basePath = basePath
 		return nil
 	}
 }


### PR DESCRIPTION
This pull request refactors the codebase to consistently use the term `basePath` instead of `baseURL` for specifying the base URL path prefix throughout the HTTP stub package. The changes affect struct fields, function parameters, internal logic, and related test cases, improving clarity and consistency in naming.

### Naming Consistency Improvements

* Renamed the `baseURL` field to `basePath` in the `Router` and `config` structs, and updated all references accordingly in `httpstub.go` and `option.go`. [[1]](diffhunk://#diff-8f05c55c5e537f5720313d8ba498403a196f37a6fb351090c8fc3e845cfeae38L64-R64) [[2]](diffhunk://#diff-086a37ef11c8fd9a2516991339db79c207741ac98dd89c8215d31a8bead2814fL27-R27)
* Updated the option function from `BaseURL` to `BasePath`, including its documentation and implementation, to match the new naming convention.

### Internal Logic Updates

* Changed all logic that prepends the base path to request paths to use `basePath` instead of `baseURL` in the router and matcher methods. [[1]](diffhunk://#diff-8f05c55c5e537f5720313d8ba498403a196f37a6fb351090c8fc3e845cfeae38L364-R366) [[2]](diffhunk://#diff-8f05c55c5e537f5720313d8ba498403a196f37a6fb351090c8fc3e845cfeae38L382-R384)
* Updated the transport struct and constructor to use `basePath` instead of `baseURL` for path handling.

### Test Case Updates

* Renamed and updated test functions and usages from `TestBaseURL`/`TestBaseURLTLS` to `TestBasePath`/`TestBasePathTLS`, and replaced `BaseURL` with `BasePath` in their setup. [[1]](diffhunk://#diff-489f145e697057271b351cba9aff2554f005f6665a675c38258fb55c045f7958L964-R965) [[2]](diffhunk://#diff-489f145e697057271b351cba9aff2554f005f6665a675c38258fb55c045f7958L1001-R1002)