### PR TITLE
fix: fix basePath handling

### DIFF
--- a/httpstub_test.go
+++ b/httpstub_test.go
@@ -1050,7 +1050,7 @@ func TestBasePathWithResponseExample(t *testing.T) {
 	mockTB := mock_httpstub.NewMockTB(ctrl)
 	mockTB.EXPECT().Helper().AnyTimes()
 
-	rt := NewRouter(mockTB, BasePath("/api/v1"), OpenApi3("testdata/openapi3.yml"))
+	rt := NewRouter(mockTB, BasePath("/api/v1"), OpenApi3("testdata/openapi3-no-base-path.yml"))
 	rt.ResponseExample(Status("*"))
 	ts := rt.Server()
 	t.Cleanup(func() {

--- a/option.go
+++ b/option.go
@@ -202,6 +202,12 @@ func Addr(addr string) Option {
 // BasePath set base URL path prefix.
 func BasePath(basePath string) Option {
 	return func(c *config) error {
+		if !strings.HasPrefix(basePath, "/") {
+			return errors.New("basePath must start with '/'")
+		}
+		if strings.HasSuffix(basePath, "/") {
+			return errors.New("basePath must not end with '/'")
+		}
 		c.basePath = basePath
 		return nil
 	}

--- a/testdata/openapi3-no-base-path.yml
+++ b/testdata/openapi3-no-base-path.yml
@@ -1,0 +1,196 @@
+openapi: 3.0.3
+info:
+  title: test spec
+  version: 0.0.1
+servers:
+  - url: 'https://example.com' # no base path
+paths:
+  /users:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    username:
+                      type: string
+                    email:
+                      type: string
+                      nullable: true
+              examples:
+                ex1:
+                  value:
+                    - username: alice
+                    - username: bob
+        '404':
+          description: Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                  - error
+              examples:
+                ex1:
+                  value:
+                    error: 'Not found'
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  type: string
+                password:
+                  type: string
+              required:
+                - username
+                - password
+      responses:
+        '201':
+          description: OK
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                  - error
+  /users/{id}:
+    get:
+      parameters:
+        - description: ID
+          explode: false
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      username:
+                        type: string
+  /help:
+    post:
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                content:
+                  type: string
+              required:
+                - name
+                - content
+      responses:
+        '201':
+          description: OK
+        '400':
+          description: Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                  - error
+  /upload:
+    post:
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              allOf:
+                - $ref: '#/components/schemas/Username'
+                -
+                  properties:
+                    upload0:
+                      type: string
+                      format: binary
+                    upload1:
+                      type: string
+                      format: binary
+            encoding:
+              upload0:
+                contentType: image/png, image/jpeg
+              upload1:
+                contentType: image/png, image/jpeg
+      responses:
+        '201':
+          description: OK
+  /notfound:
+    get:
+      responses:
+        '404':
+          description: Notfound
+  /private:
+    get:
+      responses:
+        '200':
+          description: OK
+        '403':
+          description: Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                required:
+                  - error
+  /redirect:
+    get:
+      responses:
+        '302':
+          description: Found
+        '404':
+          description: Notfound
+  /ping:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                ex1:
+                  value: pong
+components:
+  schemas:
+    Username:
+      type: object
+      properties:
+        username:
+          type: string


### PR DESCRIPTION
This pull request refactors how the `basePath` is handled in the HTTP stub router, ensuring correct path matching and server setup, and adds validation for the `basePath` option. It also introduces a new OpenAPI test fixture without a base path to improve test coverage.

**Base path handling improvements:**

* Refactored the `Server()` method in `httpstub.go` to wrap the router with a `http.ServeMux` and use `http.StripPrefix` when a `basePath` is set, ensuring requests are properly routed and matched under the base path. [[1]](diffhunk://#diff-8f05c55c5e537f5720313d8ba498403a196f37a6fb351090c8fc3e845cfeae38L195-R202) [[2]](diffhunk://#diff-8f05c55c5e537f5720313d8ba498403a196f37a6fb351090c8fc3e845cfeae38L278-R291)
* Removed logic in the `Path` matcher that prepended `basePath` to the path, since path prefixing is now handled at the server level, simplifying matcher logic. [[1]](diffhunk://#diff-8f05c55c5e537f5720313d8ba498403a196f37a6fb351090c8fc3e845cfeae38L364-L368) [[2]](diffhunk://#diff-8f05c55c5e537f5720313d8ba498403a196f37a6fb351090c8fc3e845cfeae38L382-L386)

**Configuration validation:**

* Added validation in the `BasePath` option to ensure the base path starts with `/` and does not end with `/`, preventing misconfiguration.

**Testing and fixtures:**

* Updated the test `TestBasePathWithResponseExample` to use a new OpenAPI spec (`openapi3-no-base-path.yml`) that does not specify a base path, improving coverage for this scenario.
* Added `testdata/openapi3-no-base-path.yml`, an OpenAPI 3.0.3 specification without a base path, for use in tests.