### PR TITLE
fix: fix response matching with content negotiation in ResponseExample

### DIFF
--- a/httpstub.go
+++ b/httpstub.go
@@ -753,7 +753,7 @@ func matchOne(req *http.Request, r *v3.Responses, pattern string) (status int, e
 	if len(matched) == 0 {
 		return 0, nil, "", fmt.Errorf("failed to find response matching pattern: %s", pattern)
 	}
-	idx := mrand.Intn(len(matched))
+	idx := mrand.Intn(len(matched)) //nolint:gosec
 	status, err = strconv.Atoi(matched[idx].Key())
 	if err != nil {
 		return 0, nil, "", fmt.Errorf("invalid status code: %w", err)

--- a/httpstub_test.go
+++ b/httpstub_test.go
@@ -1009,7 +1009,7 @@ func TestBasePathTLS(t *testing.T) {
 	tc := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
+				InsecureSkipVerify: true, //nolint:gosec
 			},
 		},
 	}


### PR DESCRIPTION
This pull request refactors the logic for matching response examples in the `httpstub.go` file to improve flexibility and correctness. The main update is to the `matchOne` function, which now randomly selects a matching response and properly handles content types based on the request's `Accept` header. Related changes update how response examples are selected and returned, and test cases are adjusted to use more precise status code patterns.

**Improvements to response matching and content negotiation:**

* Refactored the `matchOne` function to randomly select a matching response based on the status code pattern, parse the status code, and select the appropriate example and content type using the request's `Accept` header. This improves flexibility and correctness when multiple responses match the pattern.
* Updated the `ResponseExample` method to use the new `matchOne` signature, simplifying the logic for selecting examples and content types and improving error handling.
* Changed the response header setting to use the negotiated content type instead of the request's `Content-Type` header.
* Added import for `math/rand` as `mrand` to support random selection in `matchOne`.

**Test updates for new matching behavior:**

* Updated test cases in `httpstub_test.go` to use more precise status code patterns (e.g., `"2*"` instead of `"*"`), reflecting the improved matching logic. [[1]](diffhunk://#diff-489f145e697057271b351cba9aff2554f005f6665a675c38258fb55c045f7958L720-R720) [[2]](diffhunk://#diff-489f145e697057271b351cba9aff2554f005f6665a675c38258fb55c045f7958L1054-R1054)